### PR TITLE
Parametrized number of filters in networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ notebooks/*
 *.DS_Store
 old-models/*
 commands.md
+results.md
 fused-point-clouds/*
 dist/*
 MANIFEST

--- a/mvsnet/cnn_wrapper/mvsnetworks.py
+++ b/mvsnet/cnn_wrapper/mvsnetworks.py
@@ -7,7 +7,6 @@ MVSNet sub-models.
 from network import Network
 import sys
 sys.path.append('../')
-sys.path.append('../../')
 from MVSNet.mvsnet.utils import setup_logger
 
 logger = setup_logger('mvsnet-networks')

--- a/mvsnet/cnn_wrapper/network.py
+++ b/mvsnet/cnn_wrapper/network.py
@@ -51,7 +51,7 @@ def layer(op):
 class Network(object):
     """Class NetWork."""
 
-    def __init__(self, inputs, is_training,
+    def __init__(self, inputs, is_training, mode='normal',
                  dropout_rate=0.5, seed=None, epsilon=1e-5, reuse=False, fcn=True, regularize=True,
                  **kwargs):
         # The input nodes for this network
@@ -71,6 +71,7 @@ class Network(object):
         # The epsilon paramater in BN layer.
         self.bn_epsilon = epsilon
         self.extra_args = kwargs
+        self.base_divisor = 1 if mode == 'normal' else 2 # for dividing the base_filter size of the network
         if inputs is not None:
             # The current list of terminal nodes
             self.terminals = []

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -9,7 +9,6 @@ import math
 import tensorflow as tf
 import numpy as np
 
-#sys.path.append("../")
 from cnn_wrapper.mvsnetworks import *
 from convgru import ConvGRUCell
 from homography_warping import *
@@ -146,7 +145,7 @@ def inference(images, cams, depth_num, depth_start, depth_interval, network_mode
 
     return estimated_depth_map, prob_map#, filtered_depth_map, probability_volume
 
-def inference_mem(images, cams, depth_num, depth_start, depth_interval, is_master_gpu=True):
+def inference_mem(images, cams, depth_num, depth_start, depth_interval,network_mode, is_master_gpu=True):
     """ infer depth image from multi-view images and cameras """
 
     # dynamic gpu params
@@ -161,16 +160,16 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, is_maste
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=True)
     ref_feature = ref_tower.get_output()
     ref_feature2 = tf.square(ref_feature)
 
     view_features = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, is_training=True, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, is_training=True, mode=network_mode, reuse=True)
         view_features.append(view_tower.get_output())
     view_features = tf.stack(view_features, axis=0)
 
@@ -221,9 +220,9 @@ def inference_mem(images, cams, depth_num, depth_start, depth_interval, is_maste
 
     # filtered cost volume, size of (B, D, H, W, 1)
     if is_master_gpu:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, reuse=False)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, mode=network_mode, reuse=False)
     else:
-        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, reuse=True)
+        filtered_cost_volume_tower = RegNetUS0({'data': cost_volume}, is_training=True, mode=network_mode,  reuse=True)
     filtered_cost_volume = tf.squeeze(filtered_cost_volume_tower.get_output(), axis=-1)
 
     # depth map by softArgmin
@@ -333,7 +332,7 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
 
     return prob_volume
 
-def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, 
+def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, network_mode,
                               is_master_gpu=True, reg_type='GRU', inverse_depth=False):
     """ infer disparity image from stereo images and cameras """
 
@@ -346,13 +345,13 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end,
 
     # image feature extraction    
     if is_master_gpu:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, reuse=False)
+        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode, reuse=False)
     else:
-        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, reuse=True)
+        ref_tower = UNetDS2GN({'data': ref_image}, is_training=True, mode=network_mode,  reuse=True)
     view_towers = []
     for view in range(1, FLAGS.view_num):
         view_image = tf.squeeze(tf.slice(images, [0, view, 0, 0, 0], [-1, 1, -1, -1, -1]), axis=1)
-        view_tower = UNetDS2GN({'data': view_image}, is_training=True, reuse=True)
+        view_tower = UNetDS2GN({'data': view_image}, is_training=True, mode=network_mode, reuse=True)
         view_towers.append(view_tower)
 
     # get all homographies
@@ -368,9 +367,14 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end,
         view_homographies.append(homographies)
 
     # gru unit
-    gru1_filters = 16
-    gru2_filters = 4
-    gru3_filters = 2
+    base_divisor = 1
+    if network_mode == 'lite':
+        base_divisor = 2
+
+    gru1_filters = int(16 / base_divisor)
+    gru2_filters = int(4 / base_divisor)
+    gru3_filters = int(2 / base_divisor)
+    
     feature_shape = [FLAGS.batch_size, FLAGS.max_h/4, FLAGS.max_w/4, 32]
     gru_input_shape = [feature_shape[1], feature_shape[2]]
     state1 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru1_filters])

--- a/mvsnet/model.py
+++ b/mvsnet/model.py
@@ -278,9 +278,7 @@ def inference_prob_recurrent(images, cams, depth_num, depth_start, depth_interva
                                         depth_start=depth_start, depth_interval=depth_interval)
         view_homographies.append(homographies)
 
-    base_divisor = 1
-    if network_mode == 'lite':
-        base_divisor = 2
+    base_divisor = 1 if network_mode == 'normal' else 2
 
     gru1_filters = int(16 / base_divisor)
     gru2_filters = int(4 / base_divisor)
@@ -367,14 +365,12 @@ def inference_winner_take_all(images, cams, depth_num, depth_start, depth_end, n
         view_homographies.append(homographies)
 
     # gru unit
-    base_divisor = 1
-    if network_mode == 'lite':
-        base_divisor = 2
+    base_divisor = 1 if network_mode == 'normal' else 2
 
     gru1_filters = int(16 / base_divisor)
     gru2_filters = int(4 / base_divisor)
     gru3_filters = int(2 / base_divisor)
-    
+
     feature_shape = [FLAGS.batch_size, FLAGS.max_h/4, FLAGS.max_w/4, 32]
     gru_input_shape = [feature_shape[1], feature_shape[2]]
     state1 = tf.zeros([FLAGS.batch_size, feature_shape[1], feature_shape[2], gru1_filters])

--- a/mvsnet/mvs_data_generation/cluster_generator.py
+++ b/mvsnet/mvs_data_generation/cluster_generator.py
@@ -17,7 +17,7 @@ Copyright 2019, Chris Heinrich, Ubiquity6.
 
 
 class ClusterGenerator:
-    def __init__(self, sessions_dir, view_num, image_width=1024, image_height=768, depth_num=256,
+    def __init__(self, sessions_dir, view_num = 3, image_width=1024, image_height=768, depth_num=256,
                  interval_scale=1, base_image_size=1, include_empty=False, mode='training', val_split=0.1, rescaling=True, output_scale=0.25, flip_cams=True):
         # Setup logger
 

--- a/mvsnet/mvs_data_generation/utils.py
+++ b/mvsnet/mvs_data_generation/utils.py
@@ -29,12 +29,21 @@ Copyright 2019, Chris Heinrich, Ubiquity6.
 """
 
 
+
+
+
 def set_log_level(logger):
     if 'LOG_LEVEL' in os.environ:
         level = os.environ['LOG_LEVEL'].upper()
         exec('logger.setLevel(logging.{})'.format(level))
     else:
         logger.setLevel(logging.INFO)
+
+def setup_logger(name):
+    logging.basicConfig()
+    logger = logging.getLogger(name)
+    set_log_level(logger)
+    return logger
 
 
 # Set up logger

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -361,7 +361,7 @@ def validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, e
 
 
 def train():
-    """ training mvsnet """
+    """ Executes the main training loop for multiple epochs """
     val_sum_file = initialize_trainer()
 
     with tf.Graph().as_default(), tf.device('/cpu:0'):
@@ -390,7 +390,6 @@ def train():
         init_op, config = init_session()
 
         with tf.Session(config=config) as sess:
-
             # initialization
             total_step = 0
             sess.run(init_op)
@@ -398,7 +397,6 @@ def train():
 
             # training several epochs
             num_iterations = int(np.ceil(float(FLAGS.epoch) / float(FLAGS.num_gpus)))
-
             for epoch in range(num_iterations):
 
                 # training of one epoch

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -67,7 +67,7 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
 tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for 3DCNNs""")
-tf.app.flags.DEFINE_string('network_mode', 'lite',
+tf.app.flags.DEFINE_string('network_mode', 'normal',
                             """One of 'normal' or 'lite'. If 'lite' then networks have fewer params""")
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -18,11 +18,11 @@ import sys
 import math
 import argparse
 from random import randint
-
 import cv2
 import numpy as np
 import tensorflow as tf
 from tensorflow.python.lib.io import file_io
+
 
 # params for datasets
 tf.app.flags.DEFINE_string('train_data_root', None,
@@ -45,7 +45,7 @@ tf.app.flags.DEFINE_integer('ckpt_step', None,
 # input parameters
 tf.app.flags.DEFINE_integer('view_num', 3,
                             """Number of images (1 ref image and view_num - 1 view images).""")
-tf.app.flags.DEFINE_integer('max_d', 192,
+tf.app.flags.DEFINE_integer('max_d', 64,
                             """Maximum depth step when training.""")
 tf.app.flags.DEFINE_integer('max_w', 640,
                             """Maximum image width when training.""")
@@ -64,7 +64,6 @@ tf.app.flags.DEFINE_string('optimizer', 'rmsprop',
                            """Optimizer to use. One of 'momentum' or 'rmsprop' """)
 tf.app.flags.DEFINE_boolean('refinement', False,
                             """Whether to apply depth map refinement for 3DCNNs""")
-
 # training parameters
 tf.app.flags.DEFINE_integer('num_gpus', None,
                             """Number of GPUs.""")
@@ -91,6 +90,28 @@ tf.app.flags.DEFINE_float('train_steps_per_val', 50,
 
 FLAGS = tf.app.flags.FLAGS
 
+def load_model(total_step):
+    """ Loads pretrained model if supplied """
+    if FLAGS.ckpt_step:
+        pretrained_model_path = os.path.join(
+            FLAGS.model_load_dir, FLAGS.regularization, 'model.ckpt')
+        restorer = tf.train.Saver(tf.global_variables())
+        restorer.restore(
+            sess, '-'.join([pretrained_model_path, str(FLAGS.ckpt_step)]))
+        print(Notify.INFO, 'Pre-trained model restored from %s' %
+                ('-'.join([pretrained_model_path, str(FLAGS.ckpt_step)])), Notify.ENDC)
+        total_step = FLAGS.ckpt_step
+
+def init_session():
+    """ Returns tf global vars initializer and sets the config """
+    init_op = tf.global_variables_initializer()
+    config = tf.ConfigProto(allow_soft_placement=True)
+    config.gpu_options.allow_growth = True
+    config.inter_op_parallelism_threads = 0
+    config.intra_op_parallelism_threads = 0
+    return init_op, config
+
+
 def average_gradients(tower_grads):
     """Calculate the average gradient for each shared variable across all towers.
     Note that this function provides a synchronization point across all towers.
@@ -110,14 +131,12 @@ def average_gradients(tower_grads):
         for g, _ in grad_and_vars:
             # Add 0 dimension to the gradients to represent the tower.
             expanded_g = tf.expand_dims(g, 0)
-
             # Append on a 'tower' dimension which we will average over below.
             grads.append(expanded_g)
 
         # Average over the 'tower' dimension.
         grad = tf.concat(axis=0, values=grads)
         grad = tf.reduce_mean(grad, 0)
-
         # Keep in mind that the Variables are redundant because they are shared
         # across towers. So .. we will just return the first tower's pointer to
         # the Variable.
@@ -137,8 +156,13 @@ def generator(n, mode):
         flip_cams = True
     gen = ClusterGenerator(FLAGS.train_data_root, FLAGS.view_num, FLAGS.max_w, FLAGS.max_h,
                                 FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode=mode, flip_cams=flip_cams)
+    print('Initializing generator with mode {}'.format(mode))
     if mode == 'training':
+        global training_sample_size
         training_sample_size = len(gen.train_clusters)
+        if FLAGS.regularization == 'GRU':
+            training_sample_size = training_sample_size * 2
+        
     return iter(gen)
 
 
@@ -181,7 +205,17 @@ def parallel_iterator(mode, num_generators = FLAGS.num_gpus):
             validation_dataset, cycle_length=num_generators, prefetch_input_elements=2*num_generators, sloppy=True))
     return dataset.make_initializable_iterator()
 
-def setup_optimizer(training_sample_size):
+def setup_optimizer():
+    """ Sets up the optimizer to be used for gradient descent
+    Returns:
+        opt: The tf.optimizer object to use
+        global_step: a TF Variable representing the total number of iterations on this model 
+        """
+    global training_sample_size
+    # We initialize a dummy generator so we can get the training_sample_size
+    dummy_gen = ClusterGenerator(FLAGS.train_data_root, mode='training')
+    training_sample_size = len(dummy_gen.train_clusters)
+
     if FLAGS.stepvalue is None:
         # With this stepvalue, the lr will decay by a factor of decay_per_10_epoch every 10 epochs
         decay_per_10_epoch = 0.025
@@ -202,150 +236,162 @@ def setup_optimizer(training_sample_size):
             FLAGS.optimizer))
         raise NotImplementedError
 
-
-
-def train(training_list=None, validation_list=None):
-    """ training mvsnet """
-
+def initialize_trainer():
+    """ Prints out some info and returns a validation summary file """
     train_session_start = time.time()
     print("Training starting at time:", train_session_start)
     print("Tensorflow version:", tf.__version__)
     print("Flags:", FLAGS)
 
-    # Prepare validation summary file
+    # Prepare validation summary 
     val_sum_file = os.path.join(
         FLAGS.log_dir, 'validation_summary-{}.txt'.format(train_session_start))
     with file_io.FileIO(val_sum_file, 'w+') as f:
         header = 'train_step,val_loss,val_less_one,val_less_three\n'
         f.write(header)
+    return val_sum_file
+
+def get_batch(training_iterator, validation_iterator):
+    """ Gets a batch of data for training or validation, and reshapes for input to network """
+    if training_status:
+        images, cams, depth_image = training_iterator.get_next()
+    else:
+        images, cams, depth_image = validation_iterator.get_next()
+
+    images.set_shape(tf.TensorShape(
+        [None, FLAGS.view_num, None, None, 3]))
+    cams.set_shape(tf.TensorShape(
+        [None, FLAGS.view_num, 2, 4, 4]))
+    depth_image.set_shape(
+        tf.TensorShape([None, None, None, 1]))
+    depth_start = tf.reshape(
+        tf.slice(cams, [0, 0, 1, 3, 0], [FLAGS.batch_size, 1, 1, 1, 1]), [FLAGS.batch_size])
+    depth_interval = tf.reshape(
+        tf.slice(cams, [0, 0, 1, 3, 1], [FLAGS.batch_size, 1, 1, 1, 1]), [FLAGS.batch_size])
+    return images, cams, depth_image, depth_start, depth_interval
+
+def get_loss(images, cams, depth_image, depth_start, depth_interval, i):
+    """ Performs inference with specified network and return loss function """
+    is_master_gpu = True if i == 0 else False
+    # inference
+    if FLAGS.regularization == '3DCNNs':
+        # initial depth map
+        depth_map, prob_map = inference(
+            images, cams, FLAGS.max_d, depth_start, depth_interval, is_master_gpu)
+        # refinement
+        if FLAGS.refinement:
+            ref_image = tf.squeeze(
+                tf.slice(images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
+            refined_depth_map = depth_refine(depth_map, ref_image,
+                                                FLAGS.max_d, depth_start, depth_interval, is_master_gpu)
+                                    # regression loss
+            loss0, less_one_temp, less_three_temp = mvsnet_regression_loss(
+                depth_map, depth_image, depth_interval)
+            loss1, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
+                refined_depth_map, depth_image, depth_interval)
+            loss = (loss0 + loss1) / 2
+        else:
+            # regression loss
+            loss, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
+                depth_map, depth_image, depth_interval)
+        return loss, less_one_accuracy, less_three_accuracy
+
+    elif FLAGS.regularization == 'GRU':
+        # probability volume
+        prob_volume = inference_prob_recurrent(
+            images, cams, FLAGS.max_d, depth_start, depth_interval, is_master_gpu)
+
+        # classification loss
+        loss, mae, less_one_accuracy, less_three_accuracy, depth_map = \
+            mvsnet_classification_loss(
+                prob_volume, depth_image, FLAGS.max_d, depth_start, depth_interval)
+        return loss, less_one_accuracy, less_three_accuracy
+
+def save_model(sess, saver, total_step, step):
+    """" save model periodically """
+    if (total_step % FLAGS.snapshot == 0 or step == (training_sample_size - 1)):
+        model_folder = os.path.join(
+            FLAGS.model_dir, FLAGS.regularization)
+        ckpt_path = os.path.join(model_folder, 'model.ckpt')
+        print(Notify.INFO, 'Saving model to %s' %
+                ckpt_path, Notify.ENDC)
+        saver.save(sess, ckpt_path, global_step=total_step)
+
+def validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, epoch, total_step):
+    training_status = False
+    val_loss = []
+    val_less_one = []
+    val_less_three = []
+    for i in range(int(FLAGS.val_batch_size / FLAGS.num_gpus)):
+        # run one batch
+        start_time = time.time()
+        try:
+            out_loss, out_less_one, out_less_three = sess.run(
+                [loss, less_one_accuracy, less_three_accuracy])
+        except tf.errors.OutOfRangeError:
+            # ==> "End of dataset"
+            print("End of validation dataset")
+            break
+        duration = time.time() - start_time
+
+        print(Notify.INFO, '_validating_',
+                'epoch, %d, train step %d, val loss = %.4f, val (< 1px) = %.4f, val (< 3px) = %.4f (%.3f sec/step)' %
+                (epoch, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
+        val_loss.append(out_loss)
+        val_less_one.append(out_less_one)
+        val_less_three.append(out_less_three)
+    l = np.mean(np.asarray(val_loss))
+    l1 = np.mean(np.asarray(val_less_one))
+    l3 = np.mean(np.asarray(val_less_three))
+
+    print(Notify.INFO, '\n VAL STEP COMPLETED. Average loss: {}, Average less one: {}, Average less three: {}\n'.format(
+        l, l1, l3))
+
+    with file_io.FileIO(val_sum_file, 'a+') as f:
+        f.write('{},{},{},{}\n'.format(
+            total_step, l, l1, l3))
+    print(
+        Notify.INFO, 'Validation output summary saved to: {}'.format(val_sum_file))
+
+
+
+def train():
+    """ training mvsnet """
+    val_sum_file = initialize_trainer()
 
     with tf.Graph().as_default(), tf.device('/cpu:0'):
 
         ########## data iterator #########
         # training generators
-        """
-        train_gen = ClusterGenerator(FLAGS.train_data_root, FLAGS.view_num, FLAGS.max_w, FLAGS.max_h,
-                                     FLAGS.max_d, FLAGS.interval_scale, FLAGS.base_image_size, mode='training')
-        training_sample_size = len(train_gen.train_clusters)
-
-        if FLAGS.regularization == 'GRU':
-            training_sample_size = training_sample_size * 2
-            """
-
         training_iterator = parallel_iterator('training')
         validation_iterator = parallel_iterator('validation')
+        opt, global_step = setup_optimizer()    
 
+        global training_status
         training_status = True  # Set to true when training, false when validating
-
-        ########## optimization options ##########
-        opt, global_step = setup_optimizer(training_sample_size)
-
-
-        tower_grads = []
+        tower_grads = [] # to keep track of the gradients across all towers.
         for i in xrange(FLAGS.num_gpus):
             with tf.device('/gpu:%d' % i):
                 with tf.name_scope('Model_tower%d' % i) as scope:
-                    # generate data
-                    if training_status:
-                        images, cams, depth_image = training_iterator.get_next()
-                    else:
-                        images, cams, depth_image = validation_iterator.get_next()
-
-                    images.set_shape(tf.TensorShape(
-                        [None, FLAGS.view_num, None, None, 3]))
-                    cams.set_shape(tf.TensorShape(
-                        [None, FLAGS.view_num, 2, 4, 4]))
-                    depth_image.set_shape(
-                        tf.TensorShape([None, None, None, 1]))
-                    depth_start = tf.reshape(
-                        tf.slice(cams, [0, 0, 1, 3, 0], [FLAGS.batch_size, 1, 1, 1, 1]), [FLAGS.batch_size])
-                    depth_interval = tf.reshape(
-                        tf.slice(cams, [0, 0, 1, 3, 1], [FLAGS.batch_size, 1, 1, 1, 1]), [FLAGS.batch_size])
-
-                    is_master_gpu = False
-                    if i == 0:
-                        is_master_gpu = True
-
-                    # inference
-                    if FLAGS.regularization == '3DCNNs':
-
-                        # initial depth map
-                        depth_map, prob_map = inference(
-                            images, cams, FLAGS.max_d, depth_start, depth_interval, is_master_gpu)
-
-                        # refinement
-                        if FLAGS.refinement:
-                            ref_image = tf.squeeze(
-                                tf.slice(images, [0, 0, 0, 0, 0], [-1, 1, -1, -1, 3]), axis=1)
-                            refined_depth_map = depth_refine(depth_map, ref_image,
-                                                             FLAGS.max_d, depth_start, depth_interval, is_master_gpu)
-                                                    # regression loss
-                            loss0, less_one_temp, less_three_temp = mvsnet_regression_loss(
-                                depth_map, depth_image, depth_interval)
-                            loss1, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
-                                refined_depth_map, depth_image, depth_interval)
-                            loss = (loss0 + loss1) / 2
-                        else:
-                            # regression loss
-                            loss, less_one_accuracy, less_three_accuracy = mvsnet_regression_loss(
-                                depth_map, depth_image, depth_interval)
-
-                    elif FLAGS.regularization == 'GRU':
-
-                        # probability volume
-                        prob_volume = inference_prob_recurrent(
-                            images, cams, FLAGS.max_d, depth_start, depth_interval, is_master_gpu)
-
-                        # classification loss
-                        loss, mae, less_one_accuracy, less_three_accuracy, depth_map = \
-                            mvsnet_classification_loss(
-                                prob_volume, depth_image, FLAGS.max_d, depth_start, depth_interval)
-
-
-                    # calculate the gradients for the batch of data on this CIFAR tower.
+                    images, cams, depth_image, depth_start, depth_interval = get_batch(training_iterator, validation_iterator)
+                    loss, less_one_accuracy, less_three_accuracy = get_loss(images, cams, depth_image, depth_start, depth_interval,i)
                     grads = opt.compute_gradients(loss)
-
-                    # keep track of the gradients across all towers.
+                    
                     tower_grads.append(grads)
 
-        # average gradient
         grads = average_gradients(tower_grads)
-
-        # training opt
         train_opt = opt.apply_gradients(grads, global_step=global_step)
-
-        # saver
         saver = tf.train.Saver(tf.global_variables(), max_to_keep=None)
-        # summary_op = tf.summary.merge(summaries)
-
-        # initialization option
-        init_op = tf.global_variables_initializer()
-        config = tf.ConfigProto(allow_soft_placement=True)
-        config.gpu_options.allow_growth = True
-        config.inter_op_parallelism_threads = 0;
-        config.intra_op_parallelism_threads = 0
+        init_op, config = init_session()
 
         with tf.Session(config=config) as sess:
 
             # initialization
             total_step = 0
             sess.run(init_op)
-            # summary_writer = tf.summary.FileWriter(FLAGS.log_dir, sess.graph)
-
-            # load pre-trained model
-            if FLAGS.ckpt_step:
-                pretrained_model_path = os.path.join(
-                    FLAGS.model_load_dir, FLAGS.regularization, 'model.ckpt')
-                restorer = tf.train.Saver(tf.global_variables())
-                restorer.restore(
-                    sess, '-'.join([pretrained_model_path, str(FLAGS.ckpt_step)]))
-                print(Notify.INFO, 'Pre-trained model restored from %s' %
-                      ('-'.join([pretrained_model_path, str(FLAGS.ckpt_step)])), Notify.ENDC)
-                total_step = FLAGS.ckpt_step
+            load_model(total_step)
 
             # training several epochs
-            # Because we have num_gpus parallelized generators, we actually go through 
-            # the dataset num_gpus times in each loop below
             num_iterations = int(np.ceil(float(FLAGS.epoch) / float(FLAGS.num_gpus)))
 
             for epoch in range(num_iterations):
@@ -355,32 +401,15 @@ def train(training_list=None, validation_list=None):
                 sess.run(training_iterator.initializer)
                 sess.run(validation_iterator.initializer)
 
-                # for i in range(int(training_sample_size / FLAGS.num_gpus)):
                 for i in range(training_sample_size):
                     training_status = True
                     # run one batch
                     start_time = time.time()
                     try:
-                        skip_broken = False
-                        # Check that data was not corrupted before applying the gradient update
-                        if skip_broken:
-                            out_loss, out_less_one, out_less_three = sess.run(
-                                [loss, less_one_accuracy, less_three_accuracy])
-                            fail = False
-                            if out_less_one == 0.0 and out_less_three == 0.0:
-                                fail = True
-                            if out_loss == np.nan or fail:
-                                # This should only happen if the input data was corrupted or there is something seriously wrong with it, in which case we don't want to compute gradients and 
-                                # update network on this batch. This is a kind of inline data cleansing step.
-                                print('[ERROR] Train step failed. Will not update gradients. loss: {}, less_one: {}, less_three: {}'.format(
-                                    loss, less_one_accuracy, less_three_accuracy))
-                            else:
-                                out_opt = sess.run([train_opt])
-                        else:
-                            out_opt, out_loss, out_less_one, out_less_three = sess.run(
-                                [train_opt, loss, less_one_accuracy, less_three_accuracy])
+                        out_opt, out_loss, out_less_one, out_less_three = sess.run(
+                            [train_opt, loss, less_one_accuracy, less_three_accuracy])
                     except tf.errors.OutOfRangeError:
-                        print("End of dataset")  # ==> "End of dataset"
+                        print("End of dataset")
                         break
                     duration = time.time() - start_time
 
@@ -390,21 +419,14 @@ def train(training_list=None, validation_list=None):
                               'epoch, %d, step %d, total_step %d, loss = %.4f, (< 1px) = %.4f, (< 3px) = %.4f (%.3f sec/step)' %
                               (epoch, step, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
 
-                    # save the model checkpoint periodically
-                    if (total_step % FLAGS.snapshot == 0 or step == (training_sample_size - 1)):
-                        model_folder = os.path.join(
-                            FLAGS.model_dir, FLAGS.regularization)
-                       # if not os.path.exists(model_folder):
-                        #    os.mkdir(model_folder)
-                        ckpt_path = os.path.join(model_folder, 'model.ckpt')
-                        print(Notify.INFO, 'Saving model to %s' %
-                              ckpt_path, Notify.ENDC)
-                        saver.save(sess, ckpt_path, global_step=total_step)
+                    save_model(sess, saver, total_step, step)
                     step += FLAGS.batch_size * FLAGS.num_gpus
                     total_step += FLAGS.batch_size * FLAGS.num_gpus
 
                     # Validate model against validation set of data
                     if i % FLAGS.train_steps_per_val == 0:
+                        validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, epoch, total_step)
+                        """
                         training_status = False
                         val_loss = []
                         val_less_one = []
@@ -421,11 +443,9 @@ def train(training_list=None, validation_list=None):
                                 break
                             duration = time.time() - start_time
 
-                            # print info
-                            if step % FLAGS.display == 0:
-                                print(Notify.INFO, '_validating_',
-                                      'epoch, %d, train step %d, val loss = %.4f, val (< 1px) = %.4f, val (< 3px) = %.4f (%.3f sec/step)' %
-                                      (epoch, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
+                            print(Notify.INFO, '_validating_',
+                                    'epoch, %d, train step %d, val loss = %.4f, val (< 1px) = %.4f, val (< 3px) = %.4f (%.3f sec/step)' %
+                                    (epoch, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
                             val_loss.append(out_loss)
                             val_less_one.append(out_less_one)
                             val_less_three.append(out_less_three)
@@ -441,6 +461,7 @@ def train(training_list=None, validation_list=None):
                                 total_step, l, l1, l3))
                         print(
                             Notify.INFO, 'Validation output summary saved to: {}'.format(val_sum_file))
+                            """
 
 
 def main(argv=None):  # pylint: disable=unused-argument

--- a/mvsnet/train.py
+++ b/mvsnet/train.py
@@ -426,42 +426,6 @@ def train():
                     # Validate model against validation set of data
                     if i % FLAGS.train_steps_per_val == 0:
                         validate(sess, val_sum_file, loss, less_one_accuracy, less_three_accuracy, epoch, total_step)
-                        """
-                        training_status = False
-                        val_loss = []
-                        val_less_one = []
-                        val_less_three = []
-                        for i in range(int(FLAGS.val_batch_size / FLAGS.num_gpus)):
-                            # run one batch
-                            start_time = time.time()
-                            try:
-                                out_loss, out_less_one, out_less_three = sess.run(
-                                    [loss, less_one_accuracy, less_three_accuracy])
-                            except tf.errors.OutOfRangeError:
-                                # ==> "End of dataset"
-                                print("End of validation dataset")
-                                break
-                            duration = time.time() - start_time
-
-                            print(Notify.INFO, '_validating_',
-                                    'epoch, %d, train step %d, val loss = %.4f, val (< 1px) = %.4f, val (< 3px) = %.4f (%.3f sec/step)' %
-                                    (epoch, total_step, out_loss, out_less_one, out_less_three, duration), Notify.ENDC)
-                            val_loss.append(out_loss)
-                            val_less_one.append(out_less_one)
-                            val_less_three.append(out_less_three)
-                        l = np.mean(np.asarray(val_loss))
-                        l1 = np.mean(np.asarray(val_less_one))
-                        l3 = np.mean(np.asarray(val_less_three))
-
-                        print(Notify.INFO, '\n VAL STEP COMPLETED. Average loss: {}, Average less one: {}, Average less three: {}\n'.format(
-                            l, l1, l3))
-
-                        with file_io.FileIO(val_sum_file, 'a+') as f:
-                            f.write('{},{},{},{}\n'.format(
-                                total_step, l, l1, l3))
-                        print(
-                            Notify.INFO, 'Validation output summary saved to: {}'.format(val_sum_file))
-                            """
 
 
 def main(argv=None):  # pylint: disable=unused-argument

--- a/mvsnet/utils.py
+++ b/mvsnet/utils.py
@@ -1,0 +1,16 @@
+import logging 
+import os
+
+
+def set_log_level(logger):
+    if 'LOG_LEVEL' in os.environ:
+        level = os.environ['LOG_LEVEL'].upper()
+        exec('logger.setLevel(logging.{})'.format(level))
+    else:
+        logger.setLevel(logging.INFO)
+
+def setup_logger(name):
+    logging.basicConfig()
+    logger = logging.getLogger(name)
+    set_log_level(logger)
+    return logger


### PR DESCRIPTION
This PR parametrizes the number of filters used in the convolutional layers of MVSNet. Switching from network_mode = 'normal', to network_mode = 'lite', decreases number of parameters by approx half, and provides a 2x speedup, so will be useful for prototyping.

I also snuck in a big refactor of the main train script and some improved logging